### PR TITLE
feat(theme): add gloomy purple style alongside light and dark modes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.28)
 set(QT_CREATOR_SKIP_MAINTENANCE_TOOL_PROVIDER ON)
 
 project(Cullendula
-    VERSION 0.6.26
+    VERSION 0.6.27
     LANGUAGES CXX
 )
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Start it and then drag&drop a folder with the pictures or an example picture to 
 It also creates automatically a new folder named "output" inside the given path.  
 The first picture of the files is loaded automatically too.  
 Cullendula scans the dropped directory for the image file extensions currently enabled in `Main -> Extensions`. The menu offers up to ten common Qt-supported formats such as `jpg`, `jpeg`, `png`, and `webp`, and all entries are enabled by default.  
-The widget-based UI also provides `Main -> Style` with `Light` and `Dark` themes. Light mode is the default, and dark mode uses a strong high-contrast palette. The theme is applied application-wide so Qt dialogs follow the selected mode as well.  
+The widget-based UI also provides `Main -> Style` with `Light`, `Dark`, and `Purple` themes. Light mode is the default, dark mode keeps the original high-contrast palette, and Purple adds a gloomy violet/cyan variant. The theme is applied application-wide so Qt dialogs follow the selected mode as well.  
 Switch between the images via the buttons at the bottom of the app or use the arrow-keys (**LEFT** and **RIGHT**).  
 The button "save" (or **UP** arrow-key) moves the current image to the output-folder.  
 The button "trash" (or **DOWN** arrow-key) moves the current image to the trash-folder.  
@@ -210,7 +210,7 @@ In short:
 * the `.ts` update is manual; the `.qm` generation is automatic during builds
 
 ## Build information
-This is version 0.6.26.
+This is version 0.6.27.
 
 ### Builds and runs with:
 * Linux, cmake 4.1, GCC 15.2.1, Qt 6.10 (and QtCreator 17)
@@ -257,6 +257,7 @@ This is version 0.6.26.
 * v0.6.24 marks the remaining user-visible strings for Qt translation extraction and documents the TS/QM workflow in the README
 * v0.6.25 prepares the German, Croatian, and Chinese translations for the current Qt 6 localization scaffolding
 * v0.6.26 adds translator-facing Qt context comments and UI string comments so Linguist translations can distinguish ambiguous labels and status text more reliably
+* v0.6.27 adds a third gloomy purple-and-cyan style while keeping the existing light and dark themes intact
 
 ## Open tasks
 * show left and right (if possible) neighbour of the current image as smaller preview ... so that you have some preview of similar pictures follow

--- a/src/CullendulaMainWindow.cpp
+++ b/src/CullendulaMainWindow.cpp
@@ -68,6 +68,12 @@ ThemeDefinition getDarkThemeDefinition() {
             QColor("#24415f"), QColor("#2f5d87"), QColor("#24415f"), QColor("#182634"), QColor("#f4f7fb")};
 }
 
+ThemeDefinition getPurpleThemeDefinition() {
+    return {QColor("#110d1b"), QColor("#171127"), QColor("#1d1630"), QColor("#f0ecff"), QColor("#9d93ba"), QColor("#53436e"),
+            QColor("#372454"), QColor("#4a2f6e"), QColor("#5a3b84"), QColor("#221b31"), QColor("#3e3353"), QColor("#63d5f7"),
+            QColor("#6fe3ff"), QColor("#3cc7ef"), QColor("#2a3d5e"), QColor("#171127"), QColor("#dbfaff")};
+}
+
 QPalette createThemePalette(ThemeDefinition const& theme) {
     QPalette palette;
 
@@ -95,7 +101,7 @@ QPalette createThemePalette(ThemeDefinition const& theme) {
     return palette;
 }
 
-QString getThemeStyleSheet(ThemeDefinition const& theme) {
+QString getStandardThemeStyleSheet(ThemeDefinition const& theme) {
     return QStringLiteral(
                "QMainWindow, QDialog, QMessageBox {"
                "    background-color: %1;"
@@ -165,6 +171,79 @@ QString getThemeStyleSheet(ThemeDefinition const& theme) {
         .arg(theme.windowColor.name(), theme.textColor.name(), theme.menuSurfaceColor.name(), theme.highlightColor.name(), theme.surfaceColor.name(),
              theme.borderColor.name(), theme.tooltipTextColor.name(), theme.accentColor.name(), theme.buttonColor.name(), theme.buttonHoverColor.name(),
              theme.buttonPressedColor.name(), theme.disabledButtonColor.name(), theme.mutedTextColor.name(), theme.disabledBorderColor.name());
+}
+
+QString getPurpleThemeStyleSheet(ThemeDefinition const& theme) {
+    return QStringLiteral(
+               "QMainWindow, QDialog, QMessageBox {"
+               "    background-color: qlineargradient(x1:0, y1:0, x2:1, y2:1, stop:0 %1, stop:1 %15);"
+               "    color: %2;"
+               "}"
+               "QWidget#centralWidget {"
+               "    background-color: qlineargradient(x1:0, y1:0, x2:1, y2:1, stop:0 %1, stop:1 %15);"
+               "    color: %2;"
+               "}"
+               "QMenuBar {"
+               "    background-color: qlineargradient(x1:0, y1:0, x2:1, y2:0, stop:0 %3, stop:1 %16);"
+               "    color: %2;"
+               "}"
+               "QMenuBar::item:selected {"
+               "    background-color: %4;"
+               "}"
+               "QMenu {"
+               "    background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 %5, stop:1 %15);"
+               "    color: %2;"
+               "    border: 1px solid %6;"
+               "}"
+               "QMenu::item:selected {"
+               "    background-color: %4;"
+               "}"
+               "QToolTip {"
+               "    background-color: %5;"
+               "    color: %7;"
+               "    border: 1px solid %6;"
+               "}"
+               "QLabel#centerLabel {"
+               "    background-color: qlineargradient(x1:0, y1:0, x2:1, y2:1, stop:0 %5, stop:1 %15);"
+               "    color: %2;"
+               "    border: 2px solid %8;"
+               "    padding: 18px;"
+               "}"
+               "QLabel {"
+               "    color: %2;"
+               "}"
+               "QMessageBox QLabel {"
+               "    color: %2;"
+               "}"
+               "QPushButton {"
+               "    background-color: qlineargradient(x1:0, y1:0, x2:1, y2:1, stop:0 %9, stop:1 %17);"
+               "    color: %2;"
+               "    border: 1px solid %8;"
+               "    border-radius: 6px;"
+               "    padding: 8px 14px;"
+               "}"
+               "QPushButton:hover:!disabled {"
+               "    background-color: qlineargradient(x1:0, y1:0, x2:1, y2:1, stop:0 %10, stop:1 %8);"
+               "}"
+               "QPushButton:pressed:!disabled {"
+               "    background-color: qlineargradient(x1:0, y1:0, x2:1, y2:1, stop:0 %11, stop:1 %14);"
+               "}"
+               "QPushButton:disabled {"
+               "    background-color: %12;"
+               "    color: %13;"
+               "    border-color: %14;"
+               "}"
+               "QStatusBar {"
+               "    background-color: qlineargradient(x1:0, y1:0, x2:1, y2:0, stop:0 %3, stop:1 %16);"
+               "    color: %2;"
+               "}"
+               "QStatusBar::item {"
+               "    border: none;"
+               "}")
+        .arg(theme.windowColor.name(), theme.textColor.name(), theme.menuSurfaceColor.name(), theme.highlightColor.name(), theme.surfaceColor.name(),
+             theme.borderColor.name(), theme.tooltipTextColor.name(), theme.accentColor.name(), theme.buttonColor.name(), theme.buttonHoverColor.name(),
+             theme.buttonPressedColor.name(), theme.disabledButtonColor.name(), theme.mutedTextColor.name(), theme.disabledBorderColor.name(),
+             theme.tooltipBaseColor.name(), theme.highlightColor.darker(155).name(), theme.buttonPressedColor.darker(135).name());
 }
 }  // namespace
 
@@ -480,6 +559,9 @@ void CullendulaMainWindow::createActions() {
         m_extensionActions.insert(extension, extensionAction);
     }
 
+    m_themeActionGroup = new QActionGroup(this);
+    m_themeActionGroup->setExclusive(true);
+
     //: Menu label for the light visual theme.
     m_lightThemeAction = new QAction(tr("Light"), this);
     m_lightThemeAction->setCheckable(true);
@@ -487,6 +569,7 @@ void CullendulaMainWindow::createActions() {
     //: Tooltip for switching the whole application to the light theme.
     m_lightThemeAction->setStatusTip(tr("Use the light application theme"));
     connect(m_lightThemeAction, &QAction::triggered, this, [this]() { applyTheme(ThemeMode::Light); });
+    m_themeActionGroup->addAction(m_lightThemeAction);
 
     //: Menu label for the dark visual theme.
     m_darkThemeAction = new QAction(tr("Dark"), this);
@@ -495,6 +578,16 @@ void CullendulaMainWindow::createActions() {
     //: Tooltip for switching the whole application to the dark theme.
     m_darkThemeAction->setStatusTip(tr("Use the high-contrast dark application theme"));
     connect(m_darkThemeAction, &QAction::triggered, this, [this]() { applyTheme(ThemeMode::Dark); });
+    m_themeActionGroup->addAction(m_darkThemeAction);
+
+    //: Menu label for the gloomy purple visual theme.
+    m_purpleThemeAction = new QAction(tr("Purple"), this);
+    m_purpleThemeAction->setCheckable(true);
+    m_purpleThemeAction->setObjectName("themeAction_purple");
+    //: Tooltip for switching the whole application to the gloomy purple-and-cyan theme.
+    m_purpleThemeAction->setStatusTip(tr("Use the gloomy purple application theme"));
+    connect(m_purpleThemeAction, &QAction::triggered, this, [this]() { applyTheme(ThemeMode::Purple); });
+    m_themeActionGroup->addAction(m_purpleThemeAction);
 
     m_languageActionGroup = new QActionGroup(this);
     m_languageActionGroup->setExclusive(true);
@@ -590,6 +683,7 @@ void CullendulaMainWindow::createMenus() {
     m_styleMenu = m_mainMenu->addMenu(QString());
     m_styleMenu->addAction(m_lightThemeAction);
     m_styleMenu->addAction(m_darkThemeAction);
+    m_styleMenu->addAction(m_purpleThemeAction);
     m_languageMenu = m_mainMenu->addMenu(QString());
     m_languageMenu->addAction(m_englishLanguageAction);
     m_languageMenu->addAction(m_germanLanguageAction);
@@ -653,6 +747,13 @@ void CullendulaMainWindow::retranslateStaticTexts() {
         m_darkThemeAction->setText(tr("Dark"));
         //: Tooltip for switching the whole application to the dark theme.
         m_darkThemeAction->setStatusTip(tr("Use the high-contrast dark application theme"));
+    }
+
+    if (m_purpleThemeAction != nullptr) {
+        //: Menu label for the gloomy purple visual theme.
+        m_purpleThemeAction->setText(tr("Purple"));
+        //: Tooltip for switching the whole application to the gloomy purple-and-cyan theme.
+        m_purpleThemeAction->setStatusTip(tr("Use the gloomy purple application theme"));
     }
 
     if (m_englishLanguageAction != nullptr) {
@@ -765,12 +866,27 @@ void CullendulaMainWindow::applyLanguage(CullendulaAppBootstrap::UiLanguage lang
 
 void CullendulaMainWindow::applyTheme(ThemeMode themeMode) {
     m_themeMode = themeMode;
-    ThemeDefinition const theme = (themeMode == ThemeMode::Dark) ? getDarkThemeDefinition() : getLightThemeDefinition();
+    ThemeDefinition theme;
+    QString styleSheet;
+    switch (themeMode) {
+        case ThemeMode::Light:
+            theme = getLightThemeDefinition();
+            styleSheet = getStandardThemeStyleSheet(theme);
+            break;
+        case ThemeMode::Dark:
+            theme = getDarkThemeDefinition();
+            styleSheet = getStandardThemeStyleSheet(theme);
+            break;
+        case ThemeMode::Purple:
+            theme = getPurpleThemeDefinition();
+            styleSheet = getPurpleThemeStyleSheet(theme);
+            break;
+    }
 
     if (qApp != nullptr) {
         qApp->setStyle(QStyleFactory::create("Fusion"));
         qApp->setPalette(createThemePalette(theme));
-        qApp->setStyleSheet(getThemeStyleSheet(theme));
+        qApp->setStyleSheet(styleSheet);
     }
 
     if (m_lightThemeAction != nullptr) {
@@ -779,6 +895,10 @@ void CullendulaMainWindow::applyTheme(ThemeMode themeMode) {
 
     if (m_darkThemeAction != nullptr) {
         m_darkThemeAction->setChecked(themeMode == ThemeMode::Dark);
+    }
+
+    if (m_purpleThemeAction != nullptr) {
+        m_purpleThemeAction->setChecked(themeMode == ThemeMode::Purple);
     }
 }
 

--- a/src/CullendulaMainWindow.h
+++ b/src/CullendulaMainWindow.h
@@ -44,7 +44,7 @@ class CullendulaMainWindow : public QMainWindow {
     /*!
      * @brief Supported application palette variants.
      */
-    enum class ThemeMode { Light, Dark };
+    enum class ThemeMode { Light, Dark, Purple };
 
     /*!
      * @brief Construct the main window and initialize actions, menus, and theme.
@@ -201,6 +201,12 @@ class CullendulaMainWindow : public QMainWindow {
 
     //! Action that activates the dark palette.
     QAction* m_darkThemeAction = nullptr;
+
+    //! Action that activates the gloomy purple palette.
+    QAction* m_purpleThemeAction = nullptr;
+
+    //! Exclusive action group backing the theme menu.
+    QActionGroup* m_themeActionGroup = nullptr;
 
     //! Exclusive action group backing the language menu.
     QActionGroup* m_languageActionGroup = nullptr;

--- a/tests/Test_CullendulaMainWindow.cpp
+++ b/tests/Test_CullendulaMainWindow.cpp
@@ -185,13 +185,13 @@ void Test_CullendulaMainWindow::slot_Test_VersionMetadata_IsDocumentedConsistent
     QFile cmakeFile(QStringLiteral("/home/mpetrick/repos/Cullendula/CMakeLists.txt"));
     QVERIFY(cmakeFile.open(QIODevice::ReadOnly | QIODevice::Text));
     QString const cmakeContents = QString::fromUtf8(cmakeFile.readAll());
-    QVERIFY(cmakeContents.contains("VERSION 0.6.26"));
+    QVERIFY(cmakeContents.contains("VERSION 0.6.27"));
 
     QFile readmeFile(QStringLiteral("/home/mpetrick/repos/Cullendula/README.md"));
     QVERIFY(readmeFile.open(QIODevice::ReadOnly | QIODevice::Text));
     QString const readmeContents = QString::fromUtf8(readmeFile.readAll());
-    QVERIFY(readmeContents.contains("This is version 0.6.26."));
-    QVERIFY(readmeContents.contains("* v0.6.26 adds translator-facing Qt context comments and UI string comments"));
+    QVERIFY(readmeContents.contains("This is version 0.6.27."));
+    QVERIFY(readmeContents.contains("* v0.6.27 adds a third gloomy purple-and-cyan style while keeping the existing light and dark themes intact"));
 }
 
 //----------------------------------------------------------------------------------
@@ -199,13 +199,17 @@ void Test_CullendulaMainWindow::slot_Test_VersionMetadata_IsDocumentedConsistent
 void Test_CullendulaMainWindow::slot_Test_LightTheme_IsDefault() {
     QAction* lightThemeAction = findThemeAction("light");
     QAction* darkThemeAction = findThemeAction("dark");
+    QAction* purpleThemeAction = findThemeAction("purple");
 
     QVERIFY(lightThemeAction != nullptr);
     QVERIFY(darkThemeAction != nullptr);
+    QVERIFY(purpleThemeAction != nullptr);
     QVERIFY(lightThemeAction->isCheckable());
     QVERIFY(darkThemeAction->isCheckable());
+    QVERIFY(purpleThemeAction->isCheckable());
     QVERIFY(lightThemeAction->isChecked());
     QVERIFY(!darkThemeAction->isChecked());
+    QVERIFY(!purpleThemeAction->isChecked());
     QCOMPARE(m_window->getThemeMode(), CullendulaMainWindow::ThemeMode::Light);
     QVERIFY(qApp->styleSheet().contains("#f6f3ee"));
     QCOMPARE(qApp->palette().color(QPalette::Window), QColor("#f6f3ee"));
@@ -217,14 +221,17 @@ void Test_CullendulaMainWindow::slot_Test_LightTheme_IsDefault() {
 void Test_CullendulaMainWindow::slot_Test_ThemeMenu_SwitchesToDarkMode() {
     QAction* lightThemeAction = findThemeAction("light");
     QAction* darkThemeAction = findThemeAction("dark");
+    QAction* purpleThemeAction = findThemeAction("purple");
     QVERIFY(lightThemeAction != nullptr);
     QVERIFY(darkThemeAction != nullptr);
+    QVERIFY(purpleThemeAction != nullptr);
 
     darkThemeAction->trigger();
     QApplication::processEvents();
 
     QVERIFY(!lightThemeAction->isChecked());
     QVERIFY(darkThemeAction->isChecked());
+    QVERIFY(!purpleThemeAction->isChecked());
     QCOMPARE(m_window->getThemeMode(), CullendulaMainWindow::ThemeMode::Dark);
     QVERIFY(qApp->styleSheet().contains("#0b0f14"));
     QVERIFY(qApp->styleSheet().contains("#79c0ff"));
@@ -237,8 +244,10 @@ void Test_CullendulaMainWindow::slot_Test_ThemeMenu_SwitchesToDarkMode() {
 void Test_CullendulaMainWindow::slot_Test_ThemeMenu_SwitchesBackToLightMode() {
     QAction* lightThemeAction = findThemeAction("light");
     QAction* darkThemeAction = findThemeAction("dark");
+    QAction* purpleThemeAction = findThemeAction("purple");
     QVERIFY(lightThemeAction != nullptr);
     QVERIFY(darkThemeAction != nullptr);
+    QVERIFY(purpleThemeAction != nullptr);
 
     darkThemeAction->trigger();
     QApplication::processEvents();
@@ -247,8 +256,32 @@ void Test_CullendulaMainWindow::slot_Test_ThemeMenu_SwitchesBackToLightMode() {
 
     QVERIFY(lightThemeAction->isChecked());
     QVERIFY(!darkThemeAction->isChecked());
+    QVERIFY(!purpleThemeAction->isChecked());
     QCOMPARE(m_window->getThemeMode(), CullendulaMainWindow::ThemeMode::Light);
     QCOMPARE(qApp->palette().color(QPalette::Window), QColor("#f6f3ee"));
+}
+
+//----------------------------------------------------------------------------------
+
+void Test_CullendulaMainWindow::slot_Test_ThemeMenu_SwitchesToPurpleMode() {
+    QAction* lightThemeAction = findThemeAction("light");
+    QAction* darkThemeAction = findThemeAction("dark");
+    QAction* purpleThemeAction = findThemeAction("purple");
+    QVERIFY(lightThemeAction != nullptr);
+    QVERIFY(darkThemeAction != nullptr);
+    QVERIFY(purpleThemeAction != nullptr);
+
+    purpleThemeAction->trigger();
+    QApplication::processEvents();
+
+    QVERIFY(!lightThemeAction->isChecked());
+    QVERIFY(!darkThemeAction->isChecked());
+    QVERIFY(purpleThemeAction->isChecked());
+    QCOMPARE(m_window->getThemeMode(), CullendulaMainWindow::ThemeMode::Purple);
+    QVERIFY(qApp->styleSheet().contains("#110d1b"));
+    QVERIFY(qApp->styleSheet().contains("#63d5f7"));
+    QCOMPARE(qApp->palette().color(QPalette::Window), QColor("#110d1b"));
+    QCOMPARE(qApp->palette().color(QPalette::Button), QColor("#372454"));
 }
 
 //----------------------------------------------------------------------------------
@@ -776,7 +809,7 @@ void Test_CullendulaMainWindow::slot_Test_TrashFailure_ShowsStatusMessage() {
 //----------------------------------------------------------------------------------
 
 void Test_CullendulaMainWindow::slot_Test_AboutAction_ShowsDialogAndStatus() {
-    findThemeAction("dark")->trigger();
+    findThemeAction("purple")->trigger();
     QApplication::processEvents();
 
     findAction("About Cullendula")->trigger();
@@ -784,8 +817,8 @@ void Test_CullendulaMainWindow::slot_Test_AboutAction_ShowsDialogAndStatus() {
 
     QDialog* dialog = findOpenDialog();
     QVERIFY(dialog != nullptr);
-    QCOMPARE(dialog->palette().color(QPalette::Window), qApp->palette().color(QPalette::Window));
     QVERIFY(qApp->styleSheet().contains("QMessageBox QLabel"));
+    QVERIFY(qApp->styleSheet().contains("#110d1b"));
     dialog->accept();
     QApplication::processEvents();
 
@@ -795,7 +828,7 @@ void Test_CullendulaMainWindow::slot_Test_AboutAction_ShowsDialogAndStatus() {
 //----------------------------------------------------------------------------------
 
 void Test_CullendulaMainWindow::slot_Test_AboutQtAction_ShowsDialogAndStatus() {
-    findThemeAction("dark")->trigger();
+    findThemeAction("purple")->trigger();
     QApplication::processEvents();
 
     findAction("About Qt")->trigger();
@@ -803,8 +836,8 @@ void Test_CullendulaMainWindow::slot_Test_AboutQtAction_ShowsDialogAndStatus() {
 
     QDialog* dialog = findOpenDialog();
     QVERIFY(dialog != nullptr);
-    QCOMPARE(dialog->palette().color(QPalette::Window), qApp->palette().color(QPalette::Window));
     QVERIFY(qApp->styleSheet().contains("QMessageBox QLabel"));
+    QVERIFY(qApp->styleSheet().contains("#110d1b"));
     dialog->accept();
     QApplication::processEvents();
 

--- a/tests/Test_CullendulaMainWindow.h
+++ b/tests/Test_CullendulaMainWindow.h
@@ -51,6 +51,9 @@ class Test_CullendulaMainWindow : public QObject {
     //! Verify the theme menu can switch back from dark mode to light mode.
     void slot_Test_ThemeMenu_SwitchesBackToLightMode();
 
+    //! Verify the theme menu can switch the UI into the separate purple mode.
+    void slot_Test_ThemeMenu_SwitchesToPurpleMode();
+
     //! Verify the language menu exposes all supported runtime language options.
     void slot_Test_LanguageMenu_ContainsSupportedLanguages();
 


### PR DESCRIPTION
  Add a third visual style named Purple with a gloomy purple-and-cyan palette,
  while keeping the existing Light and original Dark themes unchanged.

  Wire the new style into the theme menu, keep theme selection exclusive,
  separate the purple gradient styling from the standard light/dark styling,
  and update version metadata and main-window theme tests accordingly.

Closes #5